### PR TITLE
Magic $model variable in blade templates

### DIFF
--- a/add-column.md
+++ b/add-column.md
@@ -1,6 +1,6 @@
 # Add Column
 
-You can add a custom column on your response by using `addColumn` api.
+You can add a custom column to your response by using `addColumn` on the `DataTable` instance.
 
 <a name="blade"></a>
 ## Add Column with Blade Syntax
@@ -12,10 +12,12 @@ Route::get('user-data', function() {
 	$model = App\User::query();
 
 	return DataTables::eloquent($model)
-				->addColumn('intro', 'Hi {{$name}}!')
+				->addColumn('intro', 'Hi {{ $name }}!')
 				->toJson();
 });
 ```
+
+> {tip} If you are building a DataTable for your `User` model which has the attributes `first_name` and `last_name`, you can directly access these properties in the blade template with `{{ $first_name }}` and `{{ $last_name }}`. You can also use `{{ $model->first_name }}` or `{{ $model->last_name }}` respectively, which is helpful if you need to call a method on the model like `{{ $model->getFullName() }}`.
 
 <a name="closure"></a>
 ## Add Column with Closure
@@ -37,7 +39,7 @@ Route::get('user-data', function() {
 <a name="view"></a>
 ## Add Column with View
 
-> {tip} You can use view to render your added column by passing the view path as the second argument on `addColumn` api.
+You can also use a blade template to render a column by passing the view path as the second argument to `addColumn`.
 
 ```php
 use DataTables;
@@ -51,15 +53,17 @@ Route::get('user-data', function() {
 });
 ```
 
-Then create your view on `resources/views/users/datatables/intro.blade.php`.
+After creating the view in `resources/views/users/datatables/intro.blade.php`, you can then access all the properties of the DataTable row directly in your view:
 ```php
 Hi {{ $name }}!
 ```
 
+> {tip} Similar to columns defined by an inline blade template, you can use `{{ $model->getFullName() }}` in views if you need access to the full model in order to call a method on it or similar.
+
 <a name="order"></a>
 ## Add Column with specific order
 
-> {tip} Just pass the column order as the third argument of `addColumn` api.
+You can use a specific order for a column by passing the order as third argument to `addColumn`:
 
 ```php
 use DataTables;


### PR DESCRIPTION
The PR tries to explain access to `$model` in blade templates (inline/view) and improves the wording of `add-column.md` slightly.

Thanks for the great package! Even if I consider myself quite familiar with it after a few years now, there is still new stuff to explore every other day. :)