### PR TITLE
Replace make(true) with toJson

### DIFF
--- a/response-object.md
+++ b/response-object.md
@@ -1,6 +1,6 @@
 # Object Response
 
-To convert the response of DataTables to an object, just pass `true` on `make` api.
+To convert the response of DataTables to an object, use `toJson` api.
 
 ```php
 use DataTables;


### PR DESCRIPTION
The old `make` api is confusing in the doc, so I replace it with the newer `toJson` method.