### PR TITLE
Fix broken link in documentation

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -41,8 +41,8 @@
 	- [Remove Column](/docs/{{package}}/{{version}}/remove-column)
 	- [Index Column](/docs/{{package}}/{{version}}/index-column)
 	- [Raw Columns](/docs/{{package}}/{{version}}/raw-columns)
-	- [Export Columns](/docs/{{package}}/{{version}}/export-columns)
-	- [Print Columns](/docs/{{package}}/{{version}}/print-columns)
+	- [Export Columns](/docs/{{package}}/{{version}}/export-column)
+	- [Print Columns](/docs/{{package}}/{{version}}/print-column)
 
 - ## Row Editing
 	- [Row Options](/docs/{{package}}/{{version}}/row-options)


### PR DESCRIPTION
This resolves https://github.com/yajra/laravel-datatables/issues/2423, and should also be applied to the 8.0 branch.