### PR TITLE
Added SearchPanes documentation

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -65,6 +65,11 @@
 	- [Order Columns](/docs/{{package}}/{{version}}/order-columns)
 	- [Order By Nulls Last](/docs/{{package}}/{{version}}/order-by-nulls-last)
 
+- ## SearchPanes
+    - [Add SearchPanes](/docs/{{package}}/{{version}}/search-panes-starter.md)
+    - [Hide Columns in SearchPanes](/docs/{{package}}/{{version}}/search-panes-hide-columns.md)
+    - [Further options](/docs/{{package}}/{{version}}/search-panes-options.md)
+
 - ## Utilities
 	- [XSS filtering](/docs/{{package}}/{{version}}/xss)
 	- [Blacklist Columns](/docs/{{package}}/{{version}}/blacklist)

--- a/quick-starter.md
+++ b/quick-starter.md
@@ -31,8 +31,10 @@ php artisan ui bootstrap --auth
 ## Install Datatables.net assets
 
 ```
-yarn add datatables.net-bs4 datatables.net-buttons-bs4
+yarn add datatables.net-bs4 datatables.net-buttons-bs4 datatables.net-select-bs4 datatables.net-searchpanes-bs4
 ```
+
+> {tip} datatables.net-select-bs4` and `datatables.net-searchpanes-bs4` are only required if you want to use SearchPanes
 
 ## Register datatables.net assets in bootstrap.js and app.scss
 
@@ -41,12 +43,16 @@ Edit `resources/js/bootstrap.js` and add the following:
     require('bootstrap');
     require('datatables.net-bs4');
     require('datatables.net-buttons-bs4');
+    require('datatables.net-select-bs4');
+    require('datatables.net-searchpanes-bs4');
 
 Edit `resources/scss/app.scss` and add the following:
 
     // DataTables
     @import "~datatables.net-bs4/css/dataTables.bootstrap4.css";
     @import "~datatables.net-buttons-bs4/css/buttons.bootstrap4.css";
+    @import '~datatables.net-select-bs4/css/select.dataTables.css';
+    @import '~datatables.net-searchpanes-dt/css/searchPanes.dataTables.css';
 
 ## Compile assets
 

--- a/search-panes-hide-columns.md
+++ b/search-panes-hide-columns.md
@@ -1,0 +1,14 @@
+# Hide Columns in SearchPanes
+
+Some columns you might not want in your SearchPanes, to hide them you can add `->searchPanes(false)` in your column
+definition:
+
+```php
+protected function getColumns() : array
+{
+    return [
+        Column::make('id')
+            ->searchPanes(false);
+    ]
+}
+```

--- a/search-panes-options.md
+++ b/search-panes-options.md
@@ -1,0 +1,30 @@
+# Further SearchPanes options
+
+```php
+public function html() : \Yajra\DataTables\Html\Builder
+{
+    return $this->builder()
+        ->searchPanes(
+            SearchPane::make()
+                ->hideCount() // Hides the count next to the options, the amount of records with the filters
+                ->hideTotal() // Hides the total how many are available without the filters
+                ->clear(false) // Hides the clear button, used to clear the user selection
+                ->controls(false) // disable controls (search for filters)
+                ->layout('columns-2') // can be used to set the layout (amount of search panes in one row)
+                ->order(['user_id', 'age']) // Sets the order of the search panes, uses the name of the search pane
+                ->orderable(false) // If the order icons should be displayed in the interface
+                ->panes( // Can be used to add additional search panes which do not belong to any existing column
+                    [
+                        // SearchPane::make()...
+                    ]
+                )
+                ->dtOpts( // Sets the options for the datatables inside the searchpanes
+                    [
+                        'paging' => true, 
+                        'pagingType' => 'numbers'
+                    ]
+                )
+                    
+            );
+}
+```

--- a/search-panes-starter.md
+++ b/search-panes-starter.md
@@ -1,0 +1,112 @@
+# Add SearchPane
+
+[SearchPanes](https://datatables.net/extensions/searchpanes/) ([example](https://datatables.net/extensions/searchpanes/examples/initialisation/simple.html))
+allow the user to quickly filter the datatable after predefined filters.
+
+> {note} To use datatables you need to make sure that the npm packages `datatables.net-select-bs4` and `datatables.net-searchpanes-bs4` are installed and added to your `app.js`/`app.css` files.
+
+## Adding SearchPanes to the frontend
+
+To be able to see SearchPanes you need to either add them fixed in the dom (displayed at all time) or add a button which
+opens them as popup.
+
+### Adding SearchPanes fixed in the dom 
+
+SearchPanes can be added to a table via the dom string, in it, they are marked with a `P` if you for example
+are using `Bfrtip` as dom you can use `PBfrtip` to display the SearchPanes at the top of the datatable, or `BfrtipP`
+to display them at the very bottom.
+
+Setting the dom String with the `\Yajra\DataTables\Html\Builder`:
+```php
+public function html() : \Yajra\DataTables\Html\Builder
+{
+    // Setting the dom string directly
+    return $this->builder()
+        ->searchPanes(SearchPane::make())
+        ->dom('PBfrtip');
+    
+    // Alternatively set the dom with parameters
+    return $this->builder()
+        ->searchPanes(SearchPane::make())
+        ->parameters([
+            'dom' => 'PBfrtip'
+        ]);
+}
+```
+
+### Adding SearchPanes with a button
+
+To add a button which opens the SearchPanes you need to make one extending `searchPanes`:
+
+```php
+public function html() : \Yajra\DataTables\Html\Builder
+{
+    // Adding via class
+    return $this->builder()
+        ->searchPanes(SearchPane::make())
+        ->buttons([
+            \Yajra\DataTables\Html\Button::make('searchPanes')
+            // other buttons...
+        ]);
+    
+    // Alternatively set the buttons with options
+    return $this->builder()
+        ->searchPanes(SearchPane::make())
+        ->parameters([
+            'buttons' => ['searchPanes', /*other buttons...*/]
+        ]);
+}
+```
+
+## Adding SearchPanes to the backend
+
+The SearchPanes can be filled in the datatables declaration via the `searchPane()` method. The method takes the column
+for which the SearchPane is, as well as the options of the SearchPane. It also allows you to set custom processing for
+the options.
+
+
+```php
+public function dataTable($query) : Yajra\DataTables\DataTableAbstract
+{
+    return datatables()
+        ->eloquent($query)
+        // Adding the SearchPane
+        ->searchPane(
+            /*
+             * This is the column for which this SearchPane definition is for 
+             */
+            'user_id',
+            
+            /*
+             * Here we define the options for our SearchPane. This should be either a collection or an array with the
+             * form:
+             * [
+             *     [
+             *          'value' => 1,
+             *          'label' => 'display value',
+             *          'total' => 5, // optional
+             *          'count' => 3 // optional
+             *     ],
+             *     [
+             *          'value' => 2,
+             *          'label' => 'display value 2',
+             *          'total' => 6, // optional
+             *          'count' => 5 // optional
+             *     ],
+             * ]
+             */
+            fn() => User::query()->select('id as value', 'name as label')->get(),
+            
+            /*
+             * This is the filter that gets executed when the user selects one or more values on the SearchPane. The
+             * values are always given in an array even if just one is selected
+             */
+            function (\Illuminate\Database\Eloquent\Builder $query, array $values) {
+                return $query
+                    ->whereIn(
+                        'id',
+                        $values);
+            }
+        );
+}
+```


### PR DESCRIPTION
Added SearchPanes documentation!

The setup and simple use is documented, there is this one comment (https://github.com/yajra/laravel-datatables/issues/2463#issuecomment-729455147) in which you talk about adding a column definition but I'm not sure why and when that is needed so I haven't documented that one for now.


Refs:
 - yajra/laravel-datatables#2475
 - yajra/laravel-datatables#2463