### PR TITLE
Tweaked SearchPanes chapter titles

### DIFF
--- a/search-panes-hide-columns.md
+++ b/search-panes-hide-columns.md
@@ -1,4 +1,4 @@
-# Hide Columns in SearchPanes
+# Exclude Columns
 
 Some columns you might not want in your SearchPanes, to hide them you can add `->searchPanes(false)` in your column
 definition:

--- a/search-panes-starter.md
+++ b/search-panes-starter.md
@@ -1,4 +1,4 @@
-# SearchPanes Extension
+# Getting Started
 
 [SearchPanes](https://datatables.net/extensions/searchpanes/) ([example](https://datatables.net/extensions/searchpanes/examples/initialisation/simple.html))
 allow the user to quickly filter the datatable after predefined filters.


### PR DESCRIPTION
Tweaked two titles in the Search panes Chapter. One of the titles was not descriptive of what happens in the chapter the other one was to long and didn't fit into the menu:
![grafik](https://user-images.githubusercontent.com/25080047/212471726-cd3efb4c-5ef3-4ea1-bb43-19bce5f60c6e.png)
