### PR TITLE
Additional response withQuery is inconsistent when navigating to next page

### DIFF
--- a/response-with.md
+++ b/response-with.md
@@ -66,6 +66,9 @@ Route::get('user-data', function() {
 
 	return DataTables::eloquent($model)
 				->withQuery('count', function($filteredQuery) {
+					// remove limit and offset firstly
+					$filteredQuery->limit = null;
+					$filteredQuery->offset = null;
 					return $filteredQuery->count();
 				})
 				->toJson();


### PR DESCRIPTION
Remove limit and offset before executing aggregate (count) query