### PR TITLE
fix: Ensure $actions property is explicitly typed as array in UserDataTable

### DIFF
--- a/buttons-custom.md
+++ b/buttons-custom.md
@@ -15,7 +15,7 @@ use Yajra\DataTables\Services\DataTable;
 
 class UsersDataTable extends DataTable
 {
-    protected $actions = ['print', 'excel', 'myCustomAction'];
+    protected array $actions = ['print', 'excel', 'myCustomAction'];
 
     public function html()
     {


### PR DESCRIPTION
This commit fixes a type error in the UserDataTable class by explicitly typing the $actions property as an array. This change aligns with the expected type in the Yajra\DataTables\Services\DataTable class, preventing runtime errors and ensuring consistent data handling.

- Updated the $actions property declaration from `protected $actions = ['print', 'excel', 'myCustomAction'];` to `protected array $actions = ['print', 'excel', 'myCustomAction'];`.
- This change leverages PHP's property type declaration feature to enforce that $actions is always an array.
- The modification enhances code robustness and readability, ensuring type safety and preventing potential issues related to incorrect data types.

By making this update, the UserDataTable class now correctly adheres to the expected data structure, improving overall stability and maintainability.