### PR TITLE
Fixes all-in-one installation command

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -28,7 +28,7 @@ composer require yajra/laravel-datatables-oracle:"^11.0"
 If you use most of the DataTables plugins like Buttons & HTML, you can use the all-in-one installer package.
 
 ```bash
-composer require yajra/laravel-datatables:^11.0
+composer require yajra/laravel-datatables:"^11.0"
 ```
 
 <a name="configuration"></a>


### PR DESCRIPTION
When I tried to install Datatables using the all-in-one command I got the following error:

![Untitled](https://github.com/user-attachments/assets/7f4d11b1-344c-4d4c-b9e7-abf444994330)

I noticed there were missing _quotes_ 